### PR TITLE
Add `confirm_empty_fields` key for text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,23 @@ Then use fields as tags in your views:
 <:fields:text value="{{ model.first_name }}"/>
 ```
 
+or
+
+```
+<:fields:text value="{{ model.first_name }}" confirm_empty_fields="false" />
+```
+
+If you use the latter, it affects behavior when a user leaves the field (`blur` event). Any value other than `false`
+for `confirm_empty_fields` puts a check mark in a field that validates even if it is empty. If you use
+`confirm_empty_fields="false"`, no check mark will be placed in text fields with no entry on blur.
+
 ### Select
 Select fields accept either an array of options, or an array of {label: '', value: ''} hashes.
 
 ```
 <:fields:select value="{{ model.role }}" options="{{ ['User', 'Admin', 'Something Else']}}"/>
 ```
-    
+
 ### Radio
 For radio buttons, pass an options array of {label: '', value: ''} hashes.
 

--- a/app/fields/controllers/main_controller.rb
+++ b/app/fields/controllers/main_controller.rb
@@ -3,11 +3,19 @@ module Fields
     before_action :setup_field
 
     def setup_field
+      @options ||= {}
+
       # Default to text fields
       if attrs.respond_to?(:type)
         @type = attrs.type
       else
         @type = 'text'
+      end
+
+      if attrs.respond_to?(:confirm_empty_fields)
+        puts "setting check_empty!"
+        @options ||= {confirm_empty_fields: true} # confirm fields by default
+        @options[:confirm_empty_fields] = attrs.confirm_empty_fields == "true"
       end
 
       unless attrs.value_last_method
@@ -36,7 +44,10 @@ module Fields
 
     # When a field goes out of focus, then we want to start checking a field
     def blur
-      model_inst.mark_field!(@field_name)
+      puts "value=#{attrs.value} and options=#{@options[:confirm_empty_fields]}"
+      unless @options[:confirm_empty_fields] == false && attrs.value.nil?
+        model_inst.mark_field!(@field_name)
+      end
     end
 
     def marked

--- a/app/fields/controllers/main_controller.rb
+++ b/app/fields/controllers/main_controller.rb
@@ -13,9 +13,8 @@ module Fields
       end
 
       if attrs.respond_to?(:confirm_empty_fields)
-        puts "setting check_empty!"
-        @options ||= {confirm_empty_fields: true} # confirm fields by default
-        @options[:confirm_empty_fields] = attrs.confirm_empty_fields == "true"
+        @options ||= {confirm_empty_fields: 'true'} # confirm fields by default
+        @options[:confirm_empty_fields] = attrs.confirm_empty_fields == "false"
       end
 
       unless attrs.value_last_method
@@ -44,9 +43,11 @@ module Fields
 
     # When a field goes out of focus, then we want to start checking a field
     def blur
-      puts "value=#{attrs.value} and options=#{@options[:confirm_empty_fields]}"
-      unless @options[:confirm_empty_fields] == false && attrs.value.nil?
-        model_inst.mark_field!(@field_name)
+      # Only place a check mark if a if :confirm_empty_fields option is present and false and
+      # if the length of the field data is non-zero. The use of try here is to prevent spurious
+      # errors from cropping up on the client side.
+      if @options[:confirm_empty_fields] != false
+        model_inst.mark_field!(@field_name) unless attrs.value.nil? || attrs.value.try(:strip).try(:length) == 0
       end
     end
 


### PR DESCRIPTION
This allows the optional `confirm_empty_fields` key to bypass check marking text fields on blur if set to "false". Default behavior is "true" which is the original behavior.
